### PR TITLE
Fix cannot read property 'init' of undefined

### DIFF
--- a/src/install.js
+++ b/src/install.js
@@ -33,20 +33,8 @@ export function install (Vue, options = {}) {
     async beforeCreate () {
       if (intercomInstalled) return;
 
-      // CF => https://developers.intercom.com/installing-intercom/docs/basic-javascript
-      if (typeof window.Intercom === 'function') {
-        this.$intercom.init();
-        this.$intercom.callIntercom('reattach_activator');
-        this.$intercom.update();
-      } else {
-        const placeholder = (...args) => placeholder.c(args);
-        placeholder.q = [];
-        placeholder.c = args => placeholder.q.push(args);
-        window.Intercom = placeholder;
-
-        this.$intercom = Vue.observable(intercom);
-        Vue.prototype.$intercom = this.$intercom;
-      }
+      this.$intercom = Vue.observable(intercom);
+      Vue.prototype.$intercom = this.$intercom;
 
       intercomInstalled = true;
     },


### PR DESCRIPTION
Hi.
In the project I work we would often get `Cannot read property 'init' of undefined`. The reason was the following: intercom plugin (which sets window.Intercom) loaded faster than `beforeCreate` of this plugin got called. I'm including the fix that helped me in this PR. Most likely it produces a fair bit of bugs. But unfortunately I don't understand the current vue-intercom code. Can you explain these two if branches that I changed please? What is the reason for setting window.Intercom yourself?